### PR TITLE
Fix library debugging issue in Java VSCode extension

### DIFF
--- a/vscode/src/debugger/debugger.ts
+++ b/vscode/src/debugger/debugger.ts
@@ -28,21 +28,28 @@ import { initializeRunConfiguration, parseArguments } from '../utils';
 import { globalState } from '../globalState';
 
 export function registerDebugger(context: ExtensionContext): void {
-    let debugTrackerFactory = new NetBeansDebugAdapterTrackerFactory();
-    context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory(extConstants.COMMAND_PREFIX, debugTrackerFactory));
-    let configInitialProvider = new NetBeansConfigurationInitialProvider();
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, configInitialProvider, vscode.DebugConfigurationProviderTriggerKind.Initial));
-    let configDynamicProvider = new NetBeansConfigurationDynamicProvider(context);
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, configDynamicProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
-    let configResolver = new NetBeansConfigurationResolver();
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, configResolver));
-    let debugDescriptionFactory = new NetBeansDebugAdapterDescriptionFactory();
-    context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(extConstants.COMMAND_PREFIX, debugDescriptionFactory));
-    initializeRunConfiguration().then(initialized => {
-        if (initialized) {
-            context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, new RunConfigurationProvider()));
-        }
-    });
+    try {
+        let debugTrackerFactory = new NetBeansDebugAdapterTrackerFactory();
+        context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory(extConstants.COMMAND_PREFIX, debugTrackerFactory));
+        let configInitialProvider = new NetBeansConfigurationInitialProvider();
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, configInitialProvider, vscode.DebugConfigurationProviderTriggerKind.Initial));
+        let configDynamicProvider = new NetBeansConfigurationDynamicProvider(context);
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, configDynamicProvider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
+        let configResolver = new NetBeansConfigurationResolver();
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, configResolver));
+        let debugDescriptionFactory = new NetBeansDebugAdapterDescriptionFactory();
+        context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory(extConstants.COMMAND_PREFIX, debugDescriptionFactory));
+        initializeRunConfiguration().then(initialized => {
+            if (initialized) {
+                context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider(extConstants.COMMAND_PREFIX, new RunConfigurationProvider()));
+            }
+        }).catch(err => {
+            console.error('Failed to initialize run configuration:', err);
+        });
+    } catch (error) {
+        console.error('Failed to register debugger:', error);
+        throw error;
+    }
 };
 
 class NetBeansDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactory {
@@ -74,12 +81,26 @@ class NetBeansDebugAdapterDescriptionFactory implements vscode.DebugAdapterDescr
                 } else {
                     // resolve(new vscode.DebugAdapterServer(debugPort));
                     const socket = net.connect(globalState.getDebugPort(), "127.0.0.1", () => { });
+                    
+                    // Add error handling for socket connection
+                    socket.on("error", (err) => {
+                        reject(new Error(`Failed to connect to debug adapter: ${err.message}`));
+                    });
+                    
                     socket.on("connect", () => {
                         const adapter = new StreamDebugAdapter();
                         socket.write(globalState?.getDebugHash() || "");
                         adapter.connect(socket, socket);
                         resolve(new vscode.DebugAdapterInlineImplementation(adapter));
                     });
+                    
+                    // Add timeout to prevent hanging
+                    setTimeout(() => {
+                        if (!socket.destroyed) {
+                            socket.destroy();
+                            reject(new Error('Debug adapter connection timeout'));
+                        }
+                    }, 10000); // 10 second timeout
                 }
             }
             fnc();
@@ -95,40 +116,45 @@ class NetBeansConfigurationInitialProvider implements vscode.DebugConfigurationP
     }
 
     async doProvideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
-        let c: LanguageClient = await globalState.getClientPromise().client;
-        if (!folder) {
+        try {
+            let c: LanguageClient = await globalState.getClientPromise().client;
+            if (!folder) {
+                return [];
+            }
+            var u: vscode.Uri | undefined;
+            if (folder && folder.uri) {
+                u = folder.uri;
+            } else {
+                u = vscode.window.activeTextEditor?.document?.uri
+            }
+            let result: vscode.DebugConfiguration[] = [];
+            const configNames: string[] | null | undefined = await vscode.commands.executeCommand(nbCommands.projectConfigurations, u?.toString());
+            if (configNames) {
+                let first: boolean = true;
+                for (let cn of configNames) {
+                    let cname: string;
+
+                    if (first) {
+                        // ignore the default config, comes first.
+                        first = false;
+                        continue;
+                    } else {
+                        cname = "Launch Java: " + cn;
+                    }
+                    const debugConfig: vscode.DebugConfiguration = {
+                        name: cname,
+                        type: extConstants.COMMAND_PREFIX,
+                        request: "launch",
+                        launchConfiguration: cn,
+                    };
+                    result.push(debugConfig);
+                }
+            }
+            return result;
+        } catch (error) {
+            console.error('Failed to provide debug configurations:', error);
             return [];
         }
-        var u: vscode.Uri | undefined;
-        if (folder && folder.uri) {
-            u = folder.uri;
-        } else {
-            u = vscode.window.activeTextEditor?.document?.uri
-        }
-        let result: vscode.DebugConfiguration[] = [];
-        const configNames: string[] | null | undefined = await vscode.commands.executeCommand(nbCommands.projectConfigurations, u?.toString());
-        if (configNames) {
-            let first: boolean = true;
-            for (let cn of configNames) {
-                let cname: string;
-
-                if (first) {
-                    // ignore the default config, comes first.
-                    first = false;
-                    continue;
-                } else {
-                    cname = "Launch Java: " + cn;
-                }
-                const debugConfig: vscode.DebugConfiguration = {
-                    name: cname,
-                    type: extConstants.COMMAND_PREFIX,
-                    request: "launch",
-                    launchConfiguration: cn,
-                };
-                result.push(debugConfig);
-            }
-        }
-        return result;
     }
 }
 
@@ -146,48 +172,53 @@ class NetBeansConfigurationDynamicProvider implements vscode.DebugConfigurationP
     }
 
     async doProvideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, context: ExtensionContext, commandValues: Map<string, string>, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
-        let c: LanguageClient = await globalState.getClientPromise().client;
-        if (!folder) {
+        try {
+            let c: LanguageClient = await globalState.getClientPromise().client;
+            if (!folder) {
+                return [];
+            }
+            let result: vscode.DebugConfiguration[] = [];
+            const attachConnectors: DebugConnector[] | null | undefined = await vscode.commands.executeCommand(extCommands.attachDebuggerConfigurations);
+            if (attachConnectors) {
+                for (let ac of attachConnectors) {
+                    const debugConfig: vscode.DebugConfiguration = {
+                        name: ac.name,
+                        type: ac.type,
+                        request: "attach",
+                    };
+                    for (let i = 0; i < ac.arguments.length; i++) {
+                        let defaultValue: string = ac.defaultValues[i];
+                        if (!defaultValue.startsWith("${command:")) {
+                            // Create a command that asks for the argument value:
+                            let cmd: string = `${extCommands.attachDebuggerConnector}.${ac.id}.${ac.arguments[i]}`;
+                            debugConfig[ac.arguments[i]] = "${command:" + cmd + "}";
+                            if (!commandValues.has(cmd)) {
+                                commandValues.set(cmd, ac.defaultValues[i]);
+                                let description: string = ac.descriptions[i];
+                                context.subscriptions.push(commands.registerCommand(cmd, async (ctx) => {
+                                    return vscode.window.showInputBox({
+                                        prompt: description,
+                                        value: commandValues.get(cmd),
+                                    }).then((value) => {
+                                        if (value) {
+                                            commandValues.set(cmd, value);
+                                        }
+                                        return value;
+                                    });
+                                }));
+                            }
+                        } else {
+                            debugConfig[ac.arguments[i]] = defaultValue;
+                        }
+                    }
+                    result.push(debugConfig);
+                }
+            }
+            return result;
+        } catch (error) {
+            console.error('Failed to provide dynamic debug configurations:', error);
             return [];
         }
-        let result: vscode.DebugConfiguration[] = [];
-        const attachConnectors: DebugConnector[] | null | undefined = await vscode.commands.executeCommand(extCommands.attachDebuggerConfigurations);
-        if (attachConnectors) {
-            for (let ac of attachConnectors) {
-                const debugConfig: vscode.DebugConfiguration = {
-                    name: ac.name,
-                    type: ac.type,
-                    request: "attach",
-                };
-                for (let i = 0; i < ac.arguments.length; i++) {
-                    let defaultValue: string = ac.defaultValues[i];
-                    if (!defaultValue.startsWith("${command:")) {
-                        // Create a command that asks for the argument value:
-                        let cmd: string = `${extCommands.attachDebuggerConnector}.${ac.id}.${ac.arguments[i]}`;
-                        debugConfig[ac.arguments[i]] = "${command:" + cmd + "}";
-                        if (!commandValues.has(cmd)) {
-                            commandValues.set(cmd, ac.defaultValues[i]);
-                            let description: string = ac.descriptions[i];
-                            context.subscriptions.push(commands.registerCommand(cmd, async (ctx) => {
-                                return vscode.window.showInputBox({
-                                    prompt: description,
-                                    value: commandValues.get(cmd),
-                                }).then((value) => {
-                                    if (value) {
-                                        commandValues.set(cmd, value);
-                                    }
-                                    return value;
-                                });
-                            }));
-                        }
-                    } else {
-                        debugConfig[ac.arguments[i]] = defaultValue;
-                    }
-                }
-                result.push(debugConfig);
-            }
-        }
-        return result;
     }
 }
 
@@ -203,9 +234,10 @@ class NetBeansConfigurationResolver implements vscode.DebugConfigurationProvider
         if (vscode.window.activeTextEditor) {
             config.file = '${file}';
         }
-        if (!config.classPaths) {
-            config.classPaths = ['any'];
-        }
+        // Remove the problematic default classpath assignment
+        // if (!config.classPaths) {
+        //     config.classPaths = ['any'];
+        // }
         if (!config.console) {
             config.console = 'internalConsole';
         }


### PR DESCRIPTION
Fix debugging in library projects by correcting classpath handling and improving robustness.

The primary issue was an invalid default classpath `['any']` being set in `NetBeansConfigurationResolver`, which prevented proper debugging in library projects. This PR removes that problematic assignment. Additionally, it enhances the debug adapter connection with error handling and a timeout, and adds robust error handling and logging to the configuration providers to prevent silent failures and improve diagnosability.

---
<a href="https://cursor.com/background-agent?bcId=bc-febcf64e-4b19-4d84-bc0c-de7f259aa8ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-febcf64e-4b19-4d84-bc0c-de7f259aa8ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>